### PR TITLE
Fix offset

### DIFF
--- a/sticky/src/main/java/com/osome/stickydecorator/ConditionItemDecorator.java
+++ b/sticky/src/main/java/com/osome/stickydecorator/ConditionItemDecorator.java
@@ -27,10 +27,12 @@ public class ConditionItemDecorator extends RecyclerView.ItemDecoration {
     @Override
     public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
         int position = parent.getChildAdapterPosition(view);
-        if (condition.isForDrawOver(position)) {
-            decor.getConditionItemOffsets(parent, outRect, view, position);
+        if (position != RecyclerView.NO_POSITION) {
+            if (condition.isForDrawOver(position)) {
+                decor.getConditionItemOffsets(parent, outRect, view, position);
+            }
+            decor.getItemOffsets(parent, outRect, view, position, state);
         }
-        decor.getItemOffsets(parent, outRect, view, position, state);
     }
 
     @Override

--- a/sticky/src/main/java/com/osome/stickydecorator/VerticalStickyDecor.java
+++ b/sticky/src/main/java/com/osome/stickydecorator/VerticalStickyDecor.java
@@ -32,8 +32,13 @@ public abstract class VerticalStickyDecor extends VerticalSectionDecor {
     @Override
     public void getItemOffsets(@NonNull RecyclerView parent, @NonNull Rect rect, @NonNull View view, int position, @NonNull RecyclerView.State state) {
         super.getItemOffsets(parent, rect, view, position, state);
-        if (reverseLayout && position == state.getItemCount() - 1) {
-            rect.top += getHeaderHeight() + getHeaderMarginTop() + getHeaderMarginTop();
+        int count = 0;
+        RecyclerView.LayoutManager layout = parent.getLayoutManager();
+        if (layout != null) {
+            count = layout.getItemCount();
+        }
+        if (reverseLayout && position == count - 1) {
+            rect.top += getHeaderHeight() + getHeaderMarginTop() + getHeaderMarginBottom();
         }
     }
 
@@ -53,7 +58,6 @@ public abstract class VerticalStickyDecor extends VerticalSectionDecor {
             super.onDrawSectionInternal(c, position, sectionBounds, child);
         }
 
-        lastHeaderHeight = sectionBounds.height();
         lastHeaderHeight = sectionBounds.height();
         int contactPoint = getHeaderHeightInternal() + getHeaderMarginTop() + getHeaderMarginBottom();
         if ((contactPoint >= sectionBounds.top && contactPoint < sectionBounds.bottom + getHeaderMarginBottom())) {


### PR DESCRIPTION
It's improves support structural changes:

1. [RecyclerView.State#getItemCount](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.State?hl=en#getItemCount()) returns the total number of items that can be laid out. Vertical offset applicable only for last view (by adapter count).
1. Check that [getChildAdapterPosition](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView?hl=en#getChildAdapterPosition(android.view.View)) != [NO_POSITION](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.html?hl=en#NO_POSITION)
1. Vertical offset is sum of header height, margin top and margin bottom.